### PR TITLE
basic support for limiting concurrent job runs by parameters

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@ THE SOFTWARE.
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.399</version>
+    <version>1.500</version>
   </parent>
 
   <artifactId>throttle-concurrents</artifactId>

--- a/src/main/java/hudson/plugins/throttleconcurrents/ThrottleJobProperty.java
+++ b/src/main/java/hudson/plugins/throttleconcurrents/ThrottleJobProperty.java
@@ -34,6 +34,7 @@ public class ThrottleJobProperty extends JobProperty<AbstractProject<?,?>> {
     private List<String> categories;
     private boolean throttleEnabled;
     private String throttleOption;
+    private boolean limitOneJobWithMatchingParams;
 
     /**
      * Store a config version so we're able to migrate config on various
@@ -46,12 +47,14 @@ public class ThrottleJobProperty extends JobProperty<AbstractProject<?,?>> {
                                Integer maxConcurrentTotal,
                                List<String> categories,
                                boolean throttleEnabled,
-                               String throttleOption) {
+                               String throttleOption,
+                               boolean limitOneJobWithMatchingParams) {
         this.maxConcurrentPerNode = maxConcurrentPerNode == null ? 0 : maxConcurrentPerNode;
         this.maxConcurrentTotal = maxConcurrentTotal == null ? 0 : maxConcurrentTotal;
         this.categories = categories;
         this.throttleEnabled = throttleEnabled;
         this.throttleOption = throttleOption;
+        this.limitOneJobWithMatchingParams = limitOneJobWithMatchingParams;
     }
 
 
@@ -87,6 +90,10 @@ public class ThrottleJobProperty extends JobProperty<AbstractProject<?,?>> {
     
     public boolean getThrottleEnabled() {
         return throttleEnabled;
+    }
+
+    public boolean getlimitOneJobWithMatchingParams() {
+        return limitOneJobWithMatchingParams;
     }
 
     public String getThrottleOption() {

--- a/src/main/resources/hudson/plugins/throttleconcurrents/Messages.properties
+++ b/src/main/resources/hudson/plugins/throttleconcurrents/Messages.properties
@@ -1,3 +1,4 @@
 ThrottleQueueTaskDispatcher.MaxCapacityOnNode=Already running {0} builds on node
 ThrottleQueueTaskDispatcher.MaxCapacityTotal=Already running {0} builds across all nodes
 ThrottleQueueTaskDispatcher.BuildPending=A build is pending launch
+ThrottleQueueTaskDispatcher.OnlyOneWithMatchingParameters=A build with matching parameters is already running

--- a/src/main/resources/hudson/plugins/throttleconcurrents/ThrottleJobProperty/config.jelly
+++ b/src/main/resources/hudson/plugins/throttleconcurrents/ThrottleJobProperty/config.jelly
@@ -20,6 +20,11 @@
              field="maxConcurrentPerNode">
       <f:textbox />
     </f:entry>
+    <f:entry title="${%Prevent multiple jobs with identical parameters from running concurrently}"
+             help="${descriptor.getHelpFile('limitOneJobWithMatchingParams')}">
+      <f:checkbox name="limitOneJobWithMatchingParams"
+                  checked="${instance.limitOneJobWithMatchingParams}" />
+    </f:entry>
     <j:if test="${!empty(descriptor.categories)}">
       <f:entry title="${%Multi-Project Throttle Category}">
         <j:forEach var="cat" items="${descriptor.categories}">

--- a/src/main/resources/hudson/plugins/throttleconcurrents/ThrottleJobProperty/help-limitOneJobWithMatchingParams.html
+++ b/src/main/resources/hudson/plugins/throttleconcurrents/ThrottleJobProperty/help-limitOneJobWithMatchingParams.html
@@ -1,0 +1,4 @@
+<div>
+  <p>If this box is checked, only one instance of the job with matching parameters will be allowed to run at a given time.
+  Other instances of this job with different parameters will be allowed to run concurrently.</p>
+</div>


### PR DESCRIPTION
this pull request adds basic support for limiting jobs with parameters to only a single concurrent run based on parameters. Runs of the job with differing parameters will still be allowed to run concurrently.
