### PR TITLE
Fix tests failures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.iml
 *.ipr
 *.iws
+.idea
 target
 work
 # eclipse =>

--- a/src/main/java/hudson/plugins/throttleconcurrents/ThrottleQueueTaskDispatcher.java
+++ b/src/main/java/hudson/plugins/throttleconcurrents/ThrottleQueueTaskDispatcher.java
@@ -90,7 +90,7 @@ public class ThrottleQueueTaskDispatcher extends QueueTaskDispatcher {
         return null;
     }
 
-    // @Override on jenkins 4.127+ , but still compatible with 1.399
+    // @Override on jenkins 1.427+ , but still compatible with 1.399
     public CauseOfBlockage canRun(Queue.Item item) {
         ThrottleJobProperty tjp = getThrottleJobProperty(item.task);
         if (tjp!=null && tjp.getThrottleEnabled()) {

--- a/src/main/java/hudson/plugins/throttleconcurrents/ThrottleQueueTaskDispatcher.java
+++ b/src/main/java/hudson/plugins/throttleconcurrents/ThrottleQueueTaskDispatcher.java
@@ -30,7 +30,8 @@ import java.util.logging.Logger;
 public class ThrottleQueueTaskDispatcher extends QueueTaskDispatcher {
 
     @Override
-    public CauseOfBlockage canTake(Node node, Task task) {
+    public CauseOfBlockage canTake(Node node, Queue.BuildableItem item) {
+        Task task = item.task;
         if (task instanceof MatrixConfiguration) {
             return null;
         }
@@ -188,7 +189,7 @@ public class ThrottleQueueTaskDispatcher extends QueueTaskDispatcher {
                     if (exec.getCurrentExecutable() != null &&
                         exec.getCurrentExecutable().getParent() != null &&
                         exec.getCurrentExecutable().getParent().getOwnerTask() != null &&
-                        exec.getCurrentExecutable().getParent().getOwnerTask().getName() == item.task.getName()) {
+                        exec.getCurrentExecutable().getParent().getOwnerTask().getName().equals(item.task.getName())) {
                         List<ParameterValue> executingUnitParams = getParametersFromWorkUnit(exec.getCurrentWorkUnit());
                         executingUnitParams = doFilterParams(paramsToCompare, executingUnitParams);
 

--- a/src/test/java/hudson/plugins/throttleconcurrents/ThrottleQueueTaskDispatcherTest.java
+++ b/src/test/java/hudson/plugins/throttleconcurrents/ThrottleQueueTaskDispatcherTest.java
@@ -358,7 +358,7 @@ public class ThrottleQueueTaskDispatcherTest extends HudsonTestCase
                     input.setValueAttribute(logger);
                 }
                 HtmlSelect select = form.getSelectByName("level");
-                HtmlOption option = select.getOptionByValue("fine");
+                HtmlOption option = select.getOptionByValue("FINE");
                 select.setSelectedAttribute(option, true);
                 break;
             }


### PR DESCRIPTION
I debugged through the code and found that the option values for HTML select are in uppercase. The test code was looking for a lowercase `fine` value for the logging level. I think this one should make jenkinsci/throttle-concurrent-builds-plugin#9 build happy.
